### PR TITLE
Chore - Update framework search paths

### DIFF
--- a/ios/RCTMGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMGL.xcodeproj/project.pbxproj
@@ -678,7 +678,10 @@
 		C4D144471F4E16F600396F26 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)",
+					"$(SRCROOT)/../../../../ios/Pods/Mapbox-iOS-SDK/dynamic",
+				);
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../react-native/React/**";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -689,7 +692,10 @@
 		C4D144481F4E16F600396F26 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)",
+					"$(SRCROOT)/../../../../ios/Pods/Mapbox-iOS-SDK/dynamic",
+				);
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../react-native/React/**";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Overview

Updates the framework search paths to also looks for the Mapbox SDK in the Pods directory.   This will eliminate the need for a patch file in consuming apps: https://github.com/robinpowered/robin-compass/blob/develop/patches/%40mapbox/react-native-mapbox-gl%2B6.2.1.patch