### PR TITLE
Chore - Use transparent background for Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
@@ -26,6 +26,7 @@ public class RCTMGLAndroidTextureMapViewManager extends RCTMGLMapViewManager {
     protected RCTMGLAndroidTextureMapView createViewInstance(ThemedReactContext themedReactContext) {
         MapboxMapOptions options = new MapboxMapOptions();
         options.textureMode(true);
+        options.translucentTextureSurface(true);
         return new RCTMGLAndroidTextureMapView(themedReactContext, this, options);
     }
 }


### PR DESCRIPTION
### Overview

Currently the map GL view loads with a black background, which is visible while it loads.  Setting the  `translucentTextureSurface` to true fixes that by setting the background to transparent.

Forcing this setting seems appropriate given this is the default behavior with iOS